### PR TITLE
Update kabocha.json

### DIFF
--- a/networks/kusama/parachain/kabocha.json
+++ b/networks/kusama/parachain/kabocha.json
@@ -1,7 +1,7 @@
 {
   "data": {
     "ParaID": "2113",
-    "Project Name": "Kabocha (KSM parachain)",
+    "Project Name": "Kabocha",
     "Logo": "../../assets/images/kabocha.svg",
     "Description (en)": "Kabocha is an emergent organism of collectives.",
     "Parachain Crowdloans Allocation (en)": "",
@@ -16,8 +16,6 @@
     "Discord Link": "https://discord.gg/MC2jKfG2s4",
     "Medium Link": "",
     "Github Link": "https://github.com/kabocha-network",
-    "Owner account": "5EXVc6jXHvhSyUj4iwsoEtfnDDawRDuD3Fe7GXACsmTYtxik"
-  },
-  "signature": "0x9213efc8a521a591da466f470ff24834753e009200ee93303d637b6256e4f355a35d1e35d474b6ce691409a2ce399ecb4cd3c8ecac161264b22e96aeda1c4c8d"
+    "Owner account": "F69ngQSVQmsKo6fiVNo5RaLHMdPyWNhH4HHihkQkpDsHnjj"
+  }
 }
- 


### PR DESCRIPTION
Updating details for paraid 2113 (Kabocha).  We've moved the paraid to another account - a pure proxy.  I've made a small change to the description, to make it consistent with other parachains (I think).

I think I have an issue with verification - since the account is a keyless proxied account, I'm not aware of a way I can sign the data.  I can't sign it directly with the owner, since there are no keys.  And I don't see a way I can use the proxy extrinsic to cause the proxy to sign either.  I could sign with one of the accounts which has full access to the proxy, but that's not going to pass the autocheck, so it would need someone to manually validate it.

Any suggestion on how I proceed?  I can make on-chain remarks with the owner account or, indeed, the paraid owner is verifiable onchain:
<img width="1149" alt="Screenshot 2023-06-18 at 01 18 17" src="https://github.com/JelliedOwl/projects-info/assets/80860490/46dc2fc7-515f-4056-a2bd-1d4fd2f25b54">
